### PR TITLE
Pro only

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -151,3 +151,4 @@ pad.sublime-project
 pad.sublime-workspace
 *.xccheckout
 
+.env

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -3,25 +3,19 @@ How to develop Hackpad under Docker
 
 If you'd like to develop Hackpad on Docker, these instructions are for you.
 
-This will let you edit this repository and see your changes reflected in the docker image. 
+This will let you edit this repository and see your changes reflected in the docker image.
 
 Getting it running
 -------------------
 
 1. Obviously, if you haven't already, you'll need to install [Docker](https://docs.docker.com/installation/).
 
-2. Build the image. From the root of this repo, run:
+2. Build the image, pull in dependencies and run the container:
 
-		docker build -t hackpad .
+        docker-compose up
 
-3. Run the container. Docker doesn't let you automatically mount a directory on your host machine in the container, so you'll need to specify by hand. 
+   The available environment variables are:
 
-	Replace /path/to/this/repo below with the path to the current repository. Leave the other path alone. 
-
-		docker run -d -p 9000:9000 -v /path/to/this/repo:/etc/hackpad/src hackpad
-		
-	The available environment variables are:
-	
         ADMIN_EMAILS - comma-separated superuser emails (default: admin@example.com)
         DB_HOST - mysql host (default: mysql)
         DB_REQUIRE_SSL - Defaults to false
@@ -70,39 +64,17 @@ Getting it running
         REQUEST_SIGNIN_SECRET - Request signin secret key
         REDIRECT_HOME_TO - Change the home page by adding a valid absolute path in this variable
         S3_BUCKET_AVATARS_FOLDER - If you want to store avatars in a folder, add it here (with the / included)
-        AWS_DOMAIN - The domain of your S3 bucket 
-        
-        
-        Note: For EACH environment variable you want to set, add "-e ENV_VAR=VALUE" at the 'docker run' command, e.x. "-e DB_HOST=localhost -e DB_PORT=3306" etc. 
+        AWS_DOMAIN - The domain of your S3 bucket
+        VERBOSE - Verbosity
 
-	This will build hackpad, run schema migrations, and then start the server. It may take a few minutes. If you want to see what's going on, do:
 
-		docker logs -f [container name]
+        Note: For EACH environment variable you want to set, add "-e ENV_VAR=VALUE" at the 'docker-compose run hackpad' command, e.x. "docker-compose run -e DB_HOST=localhost -e DB_PORT=3306 hackpad" etc.
 
-4. Fix networking (one time only). If you're on OS X or Windows, you'll need to set up port forwarding to have Hackpad work properly. Linux folk can skip this.
+3. Create a password for the admin account.
 
-	1. Open VirtualBox
+	As part of the Docker setup, Hackpad is configured with 'admin@localhost.info' as a admin account, but you'll need to create a password to log in.
 
-	2. Select the `default` image and click Settings
-
-	3. Go to Network -> Adapter 1 -> Port forwarding
-
-	4. Create a custom rule like so:
-
-		* Host IP: 127.0.0.1
-		* Host Port: 9000
-		* Guest IP: blank
-		* Guest Port: 9000
-
-	You should only have to do this once.
-
-	At this point you should be able to open http://localhost:9000 in a browser and see the Hackpad page.
-
-5. Create a password for the admin account.
-
-	As part of the Docker setup, Hackpad is configured with 'admin@localhost.info' as a admin account, but you'll need to create a password to log in. 
-
-	To do that: 
+	To do that:
 
 	1. Open http://localhost:9000 and click Log In
 
@@ -110,7 +82,7 @@ Getting it running
 
 	3. From the command line, run:
 
-		1. Find the name of your running container by running `docker ps`. Note the name. 
+		1. Find the name of your running container by running `docker ps`. Note the name.
 
 		2. Run this query and find the token:
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -66,6 +66,7 @@ Getting it running
         S3_BUCKET_AVATARS_FOLDER - If you want to store avatars in a folder, add it here (with the / included)
         AWS_DOMAIN - The domain of your S3 bucket
         VERBOSE - Verbosity
+        PRO_ONLY - Whether 'main'/primary domain Hackpad exists or only subdomains/workspaces.
 
 
         Note: For EACH environment variable you want to set, add "-e ENV_VAR=VALUE" at the 'docker-compose run hackpad' command, e.x. "docker-compose run -e DB_HOST=localhost -e DB_PORT=3306 hackpad" etc.

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,16 +11,16 @@ RUN chown hackpad:hackpad /home/hackpad
 
 WORKDIR /home/hackpad
 
-ADD . ./hackpad
-RUN rm -rf hackpad/.git
-ADD exports.sh hackpad/bin/exports.sh
-
 RUN mkdir -p lib/ data/logs/
 RUN wget https://cdn.mysql.com/archives/mysql-connector-java-5.1/mysql-connector-java-5.1.34.tar.gz && \
     tar -xzvf mysql-connector-java-5.1.34.tar.gz && \
     mv mysql-connector-java-5.1.34/mysql-connector-java-5.1.34-bin.jar lib/ && \
     rm mysql-connector-java-5.1.34.tar.gz && \
     rm -rf mysql-connector-java-5.1.34/
+
+ADD . ./hackpad
+RUN rm -rf hackpad/.git
+ADD exports.sh hackpad/bin/exports.sh
 
 RUN ./hackpad/bin/build.sh
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,46 @@
+version: '3'
+services:
+  hackpad:
+    build: .
+    ports:
+      - "9000:9000"
+    depends_on:
+      - mysql
+    environment:
+      - DB_HOST=mysql
+      - USE_HTTPS_URLS=true
+      - ENABLE_FB_LOGIN=false
+      - ENABLE_GOOGLE_LOGIN=false
+      - DISABLE_DROPBOX_SYNC=true
+      - VERBOSE=false
+      - IS_PRODUCTION=true
+      - GOOGLE_ANALYTICS_ID
+      - MIXPANEL_TOKEN
+      - TOP_DOMAINS
+      - SMTP_SERVER
+      - SMTP_USER
+      - SMTP_PASS
+      - PERSONALIZE_FOOTER
+      - ADMIN_EMAILS
+      - CUSTOM_EMAIL_ADDRESS
+      - SUPPORT_EMAIL_ADDRESS
+      - DISABLE_WORKSPACE_CREATION
+      - CANONICAL_DOMAIN
+      - REDIRECT_HOME_TO
+    volumes:
+      - hackpad:/home/hackpad/hackpad/etherpad/data
+    restart: unless-stopped
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_DATABASE: "hackpad"
+      MYSQL_USER: "hackpad"
+      MYSQL_PASSWORD: "password"
+      MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
+    volumes:
+      - db:/var/lib/mysql
+    restart: unless-stopped
+
+volumes:
+  db:
+  hackpad:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,7 @@ services:
       - DISABLE_DROPBOX_SYNC=true
       - VERBOSE=false
       - IS_PRODUCTION=true
+      - PRO_ONLY
       - GOOGLE_ANALYTICS_ID
       - MIXPANEL_TOKEN
       - TOP_DOMAINS

--- a/etherpad/etc/etherpad.local.properties.tmpl
+++ b/etherpad/etc/etherpad.local.properties.tmpl
@@ -79,3 +79,4 @@ supportEmailAddress = __support_email_address__
 etherpad.imgDefaultDomain = __img_default_domain__
 s3BucketAvatarsFolder = __s3_bucket_avatars_folder__
 personalizeFooter = __personalize_footer__
+verbose = __verbose__

--- a/start.sh
+++ b/start.sh
@@ -61,6 +61,7 @@ SECURE_COOKIE_KEY=$(escapeChars ${SECURE_COOKIE_KEY:-__secure_cookie_key__})
 REQUEST_SIGNIN_SECRET=$(escapeChars ${REQUEST_SIGNIN_SECRET:-__request_signing_secret__})
 REDIRECT_HOME_TO=$(escapeChars ${REDIRECT_HOME_TO:-false})
 PERSONALIZE_FOOTER=$(escapeChars ${PERSONALIZE_FOOTER:-false})
+VERBOSE=$(escapeChars ${VERBOSE:-true})
 
 cp hackpad/etherpad/etc/etherpad.local.properties.tmpl hackpad/etherpad/etc/etherpad.local.properties
 
@@ -98,12 +99,10 @@ sed -i.bak s/__aws_secret__/$AWS_SECRET/g hackpad/etherpad/etc/etherpad.local.pr
 sed -i.bak s/__aws_attachments_bucket__/$S3_BUCKET/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__aws_region__/$S3_REGION/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__canonical_domain__/$CANONICAL_DOMAIN/g hackpad/etherpad/etc/etherpad.local.properties
-sed -i.bak s/__google_analytics_account__/$GOOGLE_ANALYTICS_ID/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__dropbox_app_key__/$DROPBOX_KEY/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__dropbox_app_secret__/$DROPBOX_SECRET/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__disable_dropbox_sync__/$DISABLE_DROPBOX_SYNC/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__disable_creating_workspaces__/$DISABLE_WORKSPACE_CREATION/g hackpad/etherpad/etc/etherpad.local.properties
-sed -i.bak s/__mixpanel_token__/$MIXPANEL_TOKEN/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__dbc_parameters__/$DB_PARAMETERS/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__process_inbox__/$PROCESS_INBOX/g hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak s/__img_default_domain__/$CANONICAL_DOMAIN/g hackpad/etherpad/etc/etherpad.local.properties
@@ -120,6 +119,21 @@ sed -i.bak "s/^\(useHttpsUrls = \).*$/\1$USE_HTTPS_URLS/g" hackpad/etherpad/etc/
 sed -i.bak "s/^\(devMode = \).*$/\1$DEV_MODE/g" hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak "s/^\(etherpad\.isProduction = \).*$/\1$IS_PRODUCTION/g" hackpad/etherpad/etc/etherpad.local.properties
 sed -i.bak "s/^\(logDir = \).*$/\1.\/data\/logs/g" hackpad/etherpad/etc/etherpad.local.properties
-echo 'verbose = true' >> hackpad/etherpad/etc/etherpad.local.properties
+sed -i.bak s/__verbose__/$VERBOSE/g hackpad/etherpad/etc/etherpad.local.properties
+
+# Optional parameters; only add if true
+if [[ "$MIXPANEL_TOKEN" == "__mixpanel_token__" ]]; then
+    # Remove the line
+    sed -i.bak /__mixpanel_token__/d hackpad/etherpad/etc/etherpad.local.properties
+else
+    sed -i.bak s/__mixpanel_token__/$MIXPANEL_TOKEN/g hackpad/etherpad/etc/etherpad.local.properties
+fi
+
+if [[ "$GOOGLE_ANALYTICS_ID" == "__google_analytics_account__" ]]; then
+    # Remove the line
+    sed -i.bak /__google_analytics_account__/d hackpad/etherpad/etc/etherpad.local.properties
+else
+    sed -i.bak s/__google_analytics_account__/$GOOGLE_ANALYTICS_ID/g hackpad/etherpad/etc/etherpad.local.properties
+fi
 
 exec hackpad/bin/run.sh

--- a/start.sh
+++ b/start.sh
@@ -136,4 +136,12 @@ else
     sed -i.bak s/__google_analytics_account__/$GOOGLE_ANALYTICS_ID/g hackpad/etherpad/etc/etherpad.local.properties
 fi
 
+if [[ "$PRO_ONLY" == "__pro_only__" ]]; then
+    # Remove the line
+    sed -i.bak /__pro_only__/d hackpad/etherpad/etc/etherpad.local.properties
+else
+    sed -i.bak s/__pro_only__/$PRO_ONLY/g hackpad/etherpad/etc/etherpad.local.properties
+fi
+
+
 exec hackpad/bin/run.sh


### PR DESCRIPTION
Allow the PRO_ONLY parameter to be set, so Hackpad does not expect a domain with id 1 to be present in the database. Required (but not sufficient) to be able to use the SQL exports.