### PR TITLE
Disable dropbox fix

### DIFF
--- a/etherpad/src/etherpad/pad/dbwriter.js
+++ b/etherpad/src/etherpad/pad/dbwriter.js
@@ -149,13 +149,12 @@ function taskWritePad(padId) {
       var t2 = profiler.rcb("write");
       writePadNow(pad);
       t2();
-
-      success = true;
+    }
+    catch (e) {
+      log.warn("DB WRITER FAILED TO WRITE PAD: "+padId);
+      log.logException(e);
     }
     finally {
-      if (! success) {
-        log.warn("DB WRITER FAILED TO WRITE PAD: "+padId);
-      }
       profiler.print();
     }
   }, "r", true);


### PR DESCRIPTION
Fully disable Dropbox synchronization, regardless of whether account flags are set to synchronize. Required (but not sufficient) to be able to use the SQL exports (when one or more accounts had Dropbox synchronization enabled).